### PR TITLE
Improve README and add requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,59 @@
 # 🇯🇵 日本郵便住所データ管理システム（TinyDB版）
 
 ## 📦 概要
-
-このアプリは、日本郵便が提供する住所CSVデータ（`utf_ken_all.zip`、`utf_add_YYMM.zip`、`utf_del_YYMM.zip`）をGUIから取り込み・管理できるデスクトップアプリです。
-
-- Python + PySide6 + TinyDB 製
-- 住所データをローカルJSONデータベース（TinyDB）に保存
-- 差分追加／削除に対応（履歴ログあり）
-- GUI操作で一括登録・検索が可能
-- 今後の拡張：履歴復元・カスタム編集・非同期対応 etc...
-
----
+日本郵便が公開している住所CSVデータ（`utf_ken_all.zip`、`utf_add_YYMM.zip`、`utf_del_YYMM.zip`）を取り込み、ローカルの JSON データベース（TinyDB）で管理するためのデスクトップアプリです。GUI 上から一括登録や差分追加・削除、検索が行えます。
 
 ## 🛠 セットアップ
-
-### 1. 仮想環境作成（任意）
-
+### 1. 仮想環境の作成と有効化
 ```bash
 python -m venv venv
 # Windows
 venv\Scripts\activate
 # macOS/Linux
 source venv/bin/activate
+```
 
-2. 必要ライブラリのインストール
-bash
-コピーする
-編集する
+### 2. 依存パッケージのインストール
+`requirements.txt` を使用してインストールします。
+```bash
 pip install -r requirements.txt
-requirements.txt がない場合はこちら：
+```
 
-bash
-コピーする
-編集する
-pip install pyside6 tinydb qt-material requests
-3. 初期データ準備
-resources/utf_ken_all.zip に、日本郵便公式から取得したZIPを配置してください。
+### 3. 初期データの配置
+以下の ZIP ファイルを日本郵便公式サイトからダウンロードし、`resources/` フォルダーに配置してください。
+- 全国版: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_ken_all.zip>
+- 差分追加: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_add_YYMM.zip>
+- 差分削除: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_del_YYMM.zip>
 
-全国版：https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_ken_all.zip
-
-差分追加：https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_add_YYMM.zip
-
-差分削除：https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_del_YYMM.zip
-
-🚀 起動方法
-bash
-コピーする
-編集する
+## 🚀 実行方法
+仮想環境を有効化した状態で次を実行します。
+```bash
 python main.py
-初回起動時に data/address.json と data/import_log.json が自動作成されます。
+```
+初回起動時に `data/address.json` と `data/import_log.json` が自動生成されます。
 
-🖥️ 機能一覧
-機能	説明
-一括登録	utf_ken_all.zip を使って住所を全件登録します
-差分追加	utf_add_YYMM.zip を使って新住所を追加します
-差分削除	utf_del_YYMM.zip を使って住所を論理削除します
-検索	郵便番号・都道府県・市区町村・町域でリアルタイム検索可能です
-ログ表示	各操作結果が下部のログ領域に出力されます
-⚠ 履歴復元	未実装（reverse_patch.py は土台あり）
-⚠ 履歴一覧UI	未実装（import_log.json の内容表示）
-⚠ カスタム項目編集	未実装（models.py にカスタム項目定義あり）
+## 🖥️ 主な機能
+| 機能 | 説明 |
+| --- | --- |
+| 一括登録 | `utf_ken_all.zip` を読み込み全件登録 |
+| 差分追加 | `utf_add_YYMM.zip` の内容を追加登録 |
+| 差分削除 | `utf_del_YYMM.zip` の内容を論理削除 |
+| 検索 | 郵便番号・都道府県・市区町村・町域でリアルタイム検索 |
+| ログ表示 | 各操作の結果を画面下部に表示 |
 
-🎨 UIについて
-PySide6ベース
+## 🎨 UI について
+- PySide6 ベースのシンプルな GUI
+- 左メニューで画面切り替え（`QListWidget` + `QStackedWidget`）
+- 検索ページは `QTableView` + `QSortFilterProxyModel` による高速フィルタ
+- テーマには `qt-material` の `dark_teal.xml` を使用
 
-左メニューによる画面切替（QListWidget + QStackedWidget）
+## 📘 今後の拡張予定
+- 履歴の再適用・取り消し
+- 履歴一覧／復元の UI
+- カスタム項目（メモ、タグ）編集
+- CSV への部分エクスポート
+- PyInstaller による配布
 
-検索ページは QTableView + QSortFilterProxyModel による高速フィルタ
-
-テーマ：qt-material を使用（dark_teal.xml）
-
-📘 補足機能（今後）
-✅ 差分の再適用・取り消し（ログ管理）
-
-✅ UIからの履歴一覧／復元
-
-✅ カスタム項目（メモ、タグ）編集画面
-
-✅ データの部分エクスポート（CSV）
-
-✅ PyInstaller による exe 配布（予定）
-
-✅ よくある問題
-モジュールエラーで動かない
-→ python -m main のようにモジュール実行するか、__init__.py を確認してください。
-
-data/address.json がない
-→ 自動で作成されるはずですが、権限などで失敗した場合は data/ を手動で作ってください。
-
+## よくある問題
+- **モジュールが見つからない**: `python -m main` で実行するか、`__init__.py` を確認してください。
+- **`data/address.json` が作成されない**: 権限の問題などで失敗した場合は `data/` フォルダーを手動で作成してください。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+PySide6
+qt-material
+tinydb
+requests


### PR DESCRIPTION
## Summary
- clean up README in Japanese
- document virtual environment setup, package installation and execution
- add requirements.txt listing dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537c13d5d483208f749c8657bfd1a2