### PR TITLE
Implement backend search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ python main.py
 | 差分追加 | `utf_add_YYMM.zip` の内容を追加登録 |
 | 差分削除 | `utf_del_YYMM.zip` の内容を論理削除 |
 | 検索 | 郵便番号・都道府県・市区町村・町域でリアルタイム検索 |
+| 詳細検索API | バックエンドで郵便番号・都道府県・市町村を条件指定して検索 |
+| ページ付検索UI | 3 項目入力で条件指定し、30 件ずつページ送り |
 | ログ表示 | 各操作の結果を画面下部に表示 |
 
 ## 🎨 UI について
 - PySide6 ベースのシンプルな GUI
 - 左メニューで画面切り替え（`QListWidget` + `QStackedWidget`）
-- 検索ページは `QTableView` + `QSortFilterProxyModel` による高速フィルタ
+- 検索ページは郵便番号・都道府県・市区町村を指定し、30 件ずつページ送り可能
 - テーマには `qt-material` の `dark_teal.xml` を使用
 
 ## 📘 今後の拡張予定

--- a/controller.py
+++ b/controller.py
@@ -1,6 +1,7 @@
 from japanpost_backend.file_fetcher import download_zip
 from japanpost_backend.bulk_register import bulk_register
 from japanpost_backend.diff_applier import apply_add_zip, apply_del_zip
+from japanpost_backend.db_manager import get_all, search_with_filters
 
 
 class Controller:
@@ -27,3 +28,13 @@ class Controller:
             return f"[OK] 差分削除成功: {url}"
         except Exception as e:
             return f"[ERROR] 差分削除失敗: {e}"
+
+    def get_all_addresses(self):
+        records = get_all()
+        return [(r["zipcode"], r["pref"], r["city"], r["town"]) for r in records]
+
+    def search_addresses(self, zipcode: str = "", pref: str = "", city: str = "",
+                         page: int = 1, per_page: int = 30):
+        results, total = search_with_filters(zipcode, pref, city, page, per_page)
+        data = [(r["zipcode"], r["pref"], r["city"], r["town"]) for r in results]
+        return data, total


### PR DESCRIPTION
## Summary
- add address search helpers to `db_manager`
- expose new search in `Controller`
- document advanced search API in README
- add search screen inputs and pagination

## Testing
- `pip install tinydb --quiet`
- `python - <<'PY'
from japanpost_backend.db_manager import search_with_filters
res, total = search_with_filters(pref='東京都', page=1, per_page=2)
print('total', total)
print(res)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_68537f78a6388320a874f8a8dc71a6e8