### PR TITLE
Add partial match search and input limits

### DIFF
--- a/japanpost_backend/search_manager.py
+++ b/japanpost_backend/search_manager.py
@@ -30,11 +30,11 @@ def search_with_filters(
     """Search addresses with optional filters and pagination."""
     conditions = []
     if zipcode:
-        conditions.append(Address.zipcode == zipcode)
+        conditions.append(Address.zipcode.search(zipcode))
     if pref:
-        conditions.append(Address.pref == pref)
+        conditions.append(Address.pref.search(pref))
     if city:
-        conditions.append(Address.city == city)
+        conditions.append(Address.city.search(city))
 
     if conditions:
         query = reduce(lambda a, b: a & b, conditions)

--- a/ui_main.py
+++ b/ui_main.py
@@ -3,8 +3,12 @@ from PySide6.QtWidgets import (
     QHBoxLayout, QVBoxLayout, QLineEdit, QPushButton, QTextEdit, QLabel
 )
 from controller import Controller
-from PySide6.QtCore import Qt
-from PySide6.QtGui import QStandardItemModel, QStandardItem
+from PySide6.QtCore import Qt, QRegularExpression
+from PySide6.QtGui import (
+    QStandardItemModel,
+    QStandardItem,
+    QRegularExpressionValidator,
+)
 
 
 class MainWindow(QMainWindow):
@@ -86,6 +90,9 @@ class MainWindow(QMainWindow):
         form = QHBoxLayout()
         self.zip_input = QLineEdit()
         self.zip_input.setPlaceholderText("郵便番号")
+        self.zip_input.setMaxLength(7)
+        regex = QRegularExpression(r"\d{0,7}")
+        self.zip_input.setValidator(QRegularExpressionValidator(regex))
         self.pref_input = QLineEdit()
         self.pref_input.setPlaceholderText("都道府県")
         self.city_input = QLineEdit()
@@ -98,6 +105,9 @@ class MainWindow(QMainWindow):
 
         self.table = QTableView()
         v.addWidget(self.table, 1)
+
+        self.no_results_label = QLabel("")
+        v.addWidget(self.no_results_label)
 
         self.model = QStandardItemModel(0, 4)
         self.model.setHorizontalHeaderLabels(["郵便番号", "都道府県", "市区町村", "町域"])
@@ -163,6 +173,11 @@ class MainWindow(QMainWindow):
             for item in items:
                 item.setEditable(False)
             self.model.appendRow(items)
+
+        if total == 0:
+            self.no_results_label.setText("検索結果は0件です")
+        else:
+            self.no_results_label.setText("")
 
         self.current_page = page
         self.total_pages = max(1, (total + 29) // 30)


### PR DESCRIPTION
## Summary
- improve search_by_filters to use partial matching for each field
- restrict zip code field to 7 digits using a validator
- show message when search results are empty
- fix QRegularExpression import error

## Testing
- `pip install -q -r requirements.txt` *(fails: network blocked)*
- `python -m py_compile $(git ls-files '*.py')`
- `python -m main` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68538966f11483209ceef785122ac510