### PR TITLE
Fix PySide6 import error

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -8,8 +8,8 @@ from PySide6.QtGui import (
     QStandardItemModel,
     QStandardItem,
     QRegularExpressionValidator,
-    QRegularExpression,
 )
+from PySide6.QtCore import QRegularExpression
 
 
 class MainWindow(QMainWindow):


### PR DESCRIPTION
## Summary
- import `QRegularExpression` from `PySide6.QtCore` instead of `PySide6.QtGui`

## Testing
- `python -m py_compile ui_main.py`

------
https://chatgpt.com/codex/tasks/task_e_685396fccecc83208418edb6eba5ffae