### PR TITLE
Improve bulk import behavior

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1,7 +1,7 @@
 from japanpost_backend.file_fetcher import download_zip
 from japanpost_backend.bulk_register import bulk_register
 from japanpost_backend.diff_applier import apply_add_zip, apply_del_zip
-from japanpost_backend.db_manager import get_all, clear_all
+from japanpost_backend.db_manager import get_all, clear_all, count_records
 from japanpost_backend.search_manager import search_with_filters
 
 
@@ -47,4 +47,8 @@ class Controller:
             return "[OK] 全データを削除しました"
         except Exception as e:
             return f"[ERROR] 全データ削除失敗: {e}"
+
+    def get_record_count(self) -> int:
+        """Return number of records in the database."""
+        return count_records()
 

--- a/japanpost_backend/bulk_register.py
+++ b/japanpost_backend/bulk_register.py
@@ -1,8 +1,6 @@
 import os
 from japanpost_backend.data_loader import load_csv_from_zip
 from japanpost_backend.db_manager import clear_all, insert_all
-from japanpost_backend.log_manager import append_log
-from japanpost_backend.models import create_log_entry
 
 
 def bulk_register(zip_path: str, download_url: str = ""):
@@ -21,13 +19,5 @@ def bulk_register(zip_path: str, download_url: str = ""):
 
     print(f"[INFO] {len(records)} 件 登録中...")
     insert_all(records)
-
-    log_entry = create_log_entry(
-        source_file=os.path.basename(zip_path),
-        file_type="all",  # ← ← ここだけ"add"ではなく"all"
-        records=records[:5],  # ログには例として先頭5件だけ記録
-        url=download_url
-    )
-    append_log(log_entry)
 
     print(f"[OK] 一括登録が完了しました（{len(records)} 件）")

--- a/japanpost_backend/db_manager.py
+++ b/japanpost_backend/db_manager.py
@@ -35,3 +35,8 @@ def update_custom(zipcode: str, custom: dict):
 def get_all() -> List[Dict]:
     """Return all address records."""
     return db.all()
+
+
+def count_records() -> int:
+    """Return the number of address records."""
+    return len(db)

--- a/ui_main.py
+++ b/ui_main.py
@@ -1,6 +1,7 @@
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QListWidget, QStackedWidget, QTableView,
-    QHBoxLayout, QVBoxLayout, QLineEdit, QPushButton, QTextEdit, QLabel
+    QHBoxLayout, QVBoxLayout, QLineEdit, QPushButton, QTextEdit, QLabel,
+    QMessageBox
 )
 from controller import Controller
 from PySide6.QtCore import Qt
@@ -145,6 +146,16 @@ class MainWindow(QMainWindow):
             self.model.appendRow(items)
 
     def run_bulk(self, url):
+        if self.controller.get_record_count() > 0:
+            reply = QMessageBox.question(
+                self,
+                "確認",
+                "既にデータが存在します。削除して一括登録しますか？",
+                QMessageBox.Yes | QMessageBox.No,
+            )
+            if reply != QMessageBox.Yes:
+                self.output.append("[CANCELLED] 一括登録を中止しました")
+                return
         msg = self.controller.bulk_register(url)
         self.output.append(msg)
 


### PR DESCRIPTION
## Summary
- add database record counting helper
- remove logging from bulk registration
- provide record count accessor in controller
- ask the user to confirm before overwriting all data

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68539a3aca088320a6213f49eb0cbc77