### PR TITLE
Refactor PySide6 GUI and introduce custom theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ python main.py
 - PySide6 ベースのシンプルな GUI
 - 左メニューで画面切り替え（`QListWidget` + `QStackedWidget`）
 - 検索ページは郵便番号・都道府県・市区町村・町域を指定し、30 件ずつページ送り可能
-- テーマには `qt-material` の `dark_teal.xml` を使用
+- テーマには `qt-material` のカスタムテーマ `easy_reading.xml` を使用
 
 ## 📘 今後の拡張予定
 - カスタム項目（メモ、タグ）編集

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from ui_main import MainWindow
 
 def main():
     app = QApplication(sys.argv)
-    apply_stylesheet(app, theme="dark_teal.xml")  # ダーク・ティール系テーマを適用
+    apply_stylesheet(app, theme="resources/themes/easy_reading.xml")
     window = MainWindow()
     window.show()
     sys.exit(app.exec())

--- a/resources/themes/easy_reading.xml
+++ b/resources/themes/easy_reading.xml
@@ -1,0 +1,10 @@
+<!-- Custom easy reading light theme -->
+<resources>
+  <color name="primaryColor">#1976d2</color>
+  <color name="primaryLightColor">#63a4ff</color>
+  <color name="secondaryColor">#f5f5f5</color>
+  <color name="secondaryLightColor">#ffffff</color>
+  <color name="secondaryDarkColor">#e0e0e0</color>
+  <color name="primaryTextColor">#212121</color>
+  <color name="secondaryTextColor">#424242</color>
+</resources>

--- a/views/clear_page.py
+++ b/views/clear_page.py
@@ -1,0 +1,11 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton
+
+
+class ClearPage(QWidget):
+    def __init__(self):
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("登録データを全て削除"))
+        self.run_button = QPushButton("全削除 実行")
+        layout.addWidget(self.run_button)
+        layout.addStretch()

--- a/views/logs_page.py
+++ b/views/logs_page.py
@@ -1,0 +1,41 @@
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QHBoxLayout,
+    QPushButton, QTableView
+)
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QStandardItemModel, QStandardItem
+
+
+class LogsPage(QWidget):
+    def __init__(self):
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("差分取込履歴"))
+
+        self.model = QStandardItemModel(0, 5)
+        self.model.setHorizontalHeaderLabels([
+            "選択", "種別", "ファイル", "件数", "日時"
+        ])
+        self.table = QTableView()
+        self.table.setModel(self.model)
+        layout.addWidget(self.table, 1)
+
+        actions = QHBoxLayout()
+        self.restore_btn = QPushButton("復元")
+        self.delete_log_btn = QPushButton("履歴削除")
+        for w in [self.restore_btn, self.delete_log_btn]:
+            actions.addWidget(w)
+        actions.addStretch()
+        layout.addLayout(actions)
+
+        pager = QHBoxLayout()
+        self.prev_btn = QPushButton("前へ")
+        self.page_label = QLabel("1 / 1")
+        self.next_btn = QPushButton("次へ")
+        for w in [self.prev_btn, self.page_label, self.next_btn]:
+            pager.addWidget(w)
+        pager.addStretch()
+        layout.addLayout(pager)
+
+        self.current_page = 1
+        self.total_pages = 1

--- a/views/register_page.py
+++ b/views/register_page.py
@@ -1,0 +1,16 @@
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QLineEdit, QPushButton
+
+
+class RegisterPage(QWidget):
+    """Generic page for executing address data operations."""
+
+    def __init__(self, label: str, button_label: str):
+        super().__init__()
+        self.url_input = QLineEdit()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel(f"{label}用 URL"))
+        layout.addWidget(self.url_input)
+        self.run_button = QPushButton(button_label)
+        layout.addWidget(self.run_button)
+        layout.addStretch()

--- a/views/search_page.py
+++ b/views/search_page.py
@@ -1,0 +1,54 @@
+from PySide6.QtWidgets import (
+    QWidget, QVBoxLayout, QLabel, QHBoxLayout, QLineEdit,
+    QPushButton, QTableView
+)
+from PySide6.QtCore import Qt, QRegularExpression
+from PySide6.QtGui import QStandardItemModel, QStandardItem, QRegularExpressionValidator
+
+
+class SearchPage(QWidget):
+    def __init__(self):
+        super().__init__()
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("詳細検索"))
+
+        form = QHBoxLayout()
+        self.zip_input = QLineEdit()
+        self.zip_input.setPlaceholderText("郵便番号")
+        self.zip_input.setMaxLength(7)
+        regex = QRegularExpression(r"\d{0,7}")
+        self.zip_input.setValidator(QRegularExpressionValidator(regex))
+        self.pref_input = QLineEdit()
+        self.pref_input.setPlaceholderText("都道府県")
+        self.city_input = QLineEdit()
+        self.city_input.setPlaceholderText("市区町村")
+        self.town_input = QLineEdit()
+        self.town_input.setPlaceholderText("町域")
+        self.search_btn = QPushButton("検索")
+
+        for w in [self.zip_input, self.pref_input, self.city_input,
+                  self.town_input, self.search_btn]:
+            form.addWidget(w)
+        layout.addLayout(form)
+
+        self.table = QTableView()
+        layout.addWidget(self.table, 1)
+
+        self.no_results_label = QLabel("")
+        layout.addWidget(self.no_results_label)
+
+        self.model = QStandardItemModel(0, 4)
+        self.model.setHorizontalHeaderLabels(["郵便番号", "都道府県", "市区町村", "町域"])
+        self.table.setModel(self.model)
+
+        pager = QHBoxLayout()
+        self.prev_btn = QPushButton("前へ")
+        self.next_btn = QPushButton("次へ")
+        self.page_label = QLabel("1 / 1")
+        for w in [self.prev_btn, self.page_label, self.next_btn]:
+            pager.addWidget(w)
+        pager.addStretch()
+        layout.addLayout(pager)
+
+        self.current_page = 1
+        self.total_pages = 1


### PR DESCRIPTION
## Summary
- modularize GUI screens into dedicated page widgets
- apply new `easy_reading.xml` light theme
- use new pages in `MainWindow`
- document theme change in README

## Testing
- `python -m py_compile ui_main.py views/*.py main.py controller.py`
- ❌ `python main.py` *(failed: No module named 'PySide6')*

------
https://chatgpt.com/codex/tasks/task_e_6853a1ee80b88320b9417ae63b192c0e