### PR TITLE
Improve import log table UX

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -189,6 +189,7 @@ class MainWindow(QMainWindow):
     # --- log page related ---
     def load_logs_page(self, page: int = 1):
         logs, total = self.controller.fetch_logs(page, per_page=30)
+        self.logs_page.logs = logs
 
         self.logs_page.model.removeRows(0, self.logs_page.model.rowCount())
         for log in logs:
@@ -198,7 +199,12 @@ class MainWindow(QMainWindow):
             type_item = QStandardItem("追加" if log["type"] == "add" else "削除")
             file_item = QStandardItem(log.get("source_file", ""))
             count_item = QStandardItem(str(log.get("record_count", 0)))
-            ts_item = QStandardItem(log.get("timestamp", ""))
+            ts = log.get("timestamp", "")
+            try:
+                ts = __import__("datetime").datetime.fromisoformat(ts).strftime("%Y/%m/%d %H:%M")
+            except Exception:
+                pass
+            ts_item = QStandardItem(ts)
             for item in [check_item, type_item, file_item, count_item, ts_item]:
                 item.setEditable(False)
             self.logs_page.model.appendRow([check_item, type_item, file_item, count_item, ts_item])

--- a/views/logs_page.py
+++ b/views/logs_page.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QHBoxLayout,
-    QPushButton, QTableView
+    QPushButton, QTableView, QMessageBox, QHeaderView
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItemModel, QStandardItem
@@ -18,7 +18,14 @@ class LogsPage(QWidget):
         ])
         self.table = QTableView()
         self.table.setModel(self.model)
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        self.table.setColumnWidth(2, 250)
+        self.table.setColumnWidth(4, 150)
+        self.table.doubleClicked.connect(self._show_details)
         layout.addWidget(self.table, 1)
+
+        self.logs = []
 
         actions = QHBoxLayout()
         self.restore_btn = QPushButton("復元")
@@ -39,3 +46,13 @@ class LogsPage(QWidget):
 
         self.current_page = 1
         self.total_pages = 1
+
+    def _show_details(self, index):
+        row = index.row()
+        if row >= len(self.logs):
+            return
+        log = self.logs[row]
+        details = log.get("details", [])
+        detail_lines = [f"{d.get('zipcode', '')} {d.get('pref', '')} {d.get('town', '')}" for d in details]
+        text = "\n".join(detail_lines) if detail_lines else "(詳細なし)"
+        QMessageBox.information(self, "詳細", text)


### PR DESCRIPTION
## Summary
- resize file name and timestamp columns on the import log page
- display formatted timestamps
- show log details when a row is double-clicked

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853a690fd18832091813c628b929448