### PR TITLE
Add log reapply feature and detail viewer

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -1,6 +1,9 @@
 from japanpost_backend.file_fetcher import download_zip
 from japanpost_backend.bulk_register import bulk_register
-from japanpost_backend.diff_applier import apply_add_zip, apply_del_zip
+from japanpost_backend.diff_applier import (
+    apply_add_zip, apply_del_zip,
+)
+from japanpost_backend.reapply_patch import reapply_log_entry
 from japanpost_backend.db_manager import get_all, clear_all, count_records
 from japanpost_backend.search_manager import search_with_filters
 from japanpost_backend.log_manager import get_logs, delete_log
@@ -70,4 +73,10 @@ class Controller:
         for idx in sorted(indices, reverse=True):
             delete_log(idx)
         return "[OK] 履歴を削除しました"
+
+    def reapply_logs(self, indices):
+        msgs = []
+        for idx in sorted(indices):
+            msgs.append(reapply_log_entry(idx))
+        return "\n".join(msgs)
 

--- a/japanpost_backend/diff_applier.py
+++ b/japanpost_backend/diff_applier.py
@@ -58,3 +58,23 @@ def apply_del_zip(zip_path: str, download_url: str = ""):
     )
     append_log(log)
     print(f"[OK] {len(records)} 件を削除しました。")
+
+def apply_add_zip_without_log(zip_path: str):
+    """追加データを登録するが履歴を記録しない"""
+    records = load_csv_from_zip(zip_path)
+    if not records:
+        print(f"[WARN] データが空: {zip_path}")
+        return
+    insert_all(records)
+    print(f"[OK] {len(records)} 件を追加しました。")
+
+
+def apply_del_zip_without_log(zip_path: str):
+    """削除データを削除するが履歴を記録しない"""
+    records = load_csv_from_zip(zip_path)
+    if not records:
+        print(f"[WARN] データが空: {zip_path}")
+        return
+    for record in records:
+        remove_by_zipcode(record["zipcode"])
+    print(f"[OK] {len(records)} 件を削除しました。")

--- a/japanpost_backend/reapply_patch.py
+++ b/japanpost_backend/reapply_patch.py
@@ -1,0 +1,44 @@
+import os
+from typing import Literal
+from .file_fetcher import download_zip
+from .diff_applier import (
+    apply_add_zip_without_log,
+    apply_del_zip_without_log,
+)
+from .log_manager import load_logs
+
+RESOURCE_DIR = "resources"
+
+
+def reapply_log_entry(index: int) -> str:
+    """Reapply the import corresponding to a log entry without creating logs."""
+    logs = load_logs()
+    if index < 0 or index >= len(logs):
+        return f"[ERROR] 指定インデックスが無効: {index}"
+
+    log = logs[index]
+    entry_type: Literal["add", "del"] = log.get("type")
+    url = log.get("download_url", "")
+    src = log.get("source_file", "")
+
+    try:
+        # get zip path (download again if needed)
+        if url:
+            zip_path = download_zip(url)
+        elif src:
+            zip_path = os.path.join(RESOURCE_DIR, src)
+            if not os.path.exists(zip_path):
+                return f"[ERROR] ZIP が見つかりません: {src}"
+        else:
+            return f"[ERROR] ZIP 情報がありません: {index}"
+
+        if entry_type == "add":
+            apply_add_zip_without_log(zip_path)
+            return f"[REAPPLIED] add ログ #{index} を再実行しました"
+        elif entry_type == "del":
+            apply_del_zip_without_log(zip_path)
+            return f"[REAPPLIED] del ログ #{index} を再実行しました"
+        else:
+            return f"[ERROR] 未知のログタイプ: {entry_type}"
+    except Exception as e:
+        return f"[ERROR] 再実行失敗: {e}"

--- a/ui_main.py
+++ b/ui_main.py
@@ -74,6 +74,7 @@ class MainWindow(QMainWindow):
         self.search_page.next_btn.clicked.connect(self.next_page)
         self.logs_page.restore_btn.clicked.connect(self.restore_selected_logs)
         self.logs_page.delete_log_btn.clicked.connect(self.delete_selected_logs)
+        self.logs_page.reapply_btn.clicked.connect(self.reapply_selected_logs)
         self.logs_page.prev_btn.clicked.connect(
             lambda: self.load_logs_page(self.log_current_page - 1))
         self.logs_page.next_btn.clicked.connect(
@@ -236,6 +237,10 @@ class MainWindow(QMainWindow):
         logs, total = self.controller.fetch_logs(page, per_page=30)
         self.logs_page.logs = logs
 
+        self.logs_page.details_model.removeRows(
+            0, self.logs_page.details_model.rowCount()
+        )
+
         self.logs_page.model.removeRows(0, self.logs_page.model.rowCount())
         for log in logs:
             check_item = QStandardItem()
@@ -282,5 +287,13 @@ class MainWindow(QMainWindow):
         if not indices:
             return
         msg = self.controller.delete_logs(indices)
+        self.output.append(msg)
+        self.load_logs_page(self.log_current_page)
+
+    def reapply_selected_logs(self):
+        indices = self._selected_log_indices()
+        if not indices:
+            return
+        msg = self.controller.reapply_logs(indices)
         self.output.append(msg)
         self.load_logs_page(self.log_current_page)

--- a/views/logs_page.py
+++ b/views/logs_page.py
@@ -23,14 +23,24 @@ class LogsPage(QWidget):
         self.table.setColumnWidth(2, 250)
         self.table.setColumnWidth(4, 150)
         self.table.doubleClicked.connect(self._show_details)
+        self.table.clicked.connect(self._display_details)
         layout.addWidget(self.table, 1)
+
+        self.details_model = QStandardItemModel(0, 3)
+        self.details_model.setHorizontalHeaderLabels(["郵便番号", "都道府県", "町域"])
+        self.details_table = QTableView()
+        self.details_table.setModel(self.details_model)
+        d_header = self.details_table.horizontalHeader()
+        d_header.setSectionResizeMode(QHeaderView.ResizeToContents)
+        layout.addWidget(self.details_table, 1)
 
         self.logs = []
 
         actions = QHBoxLayout()
         self.restore_btn = QPushButton("復元")
+        self.reapply_btn = QPushButton("再実行")
         self.delete_log_btn = QPushButton("履歴削除")
-        for w in [self.restore_btn, self.delete_log_btn]:
+        for w in [self.restore_btn, self.reapply_btn, self.delete_log_btn]:
             actions.addWidget(w)
         actions.addStretch()
         layout.addLayout(actions)
@@ -56,3 +66,20 @@ class LogsPage(QWidget):
         detail_lines = [f"{d.get('zipcode', '')} {d.get('pref', '')} {d.get('town', '')}" for d in details]
         text = "\n".join(detail_lines) if detail_lines else "(詳細なし)"
         QMessageBox.information(self, "詳細", text)
+
+    def _display_details(self, index):
+        row = index.row()
+        if row >= len(self.logs):
+            return
+        self.details_model.removeRows(0, self.details_model.rowCount())
+        details = self.logs[row].get("details", [])
+        for d in details:
+            items = [
+                QStandardItem(d.get("zipcode", "")),
+                QStandardItem(d.get("pref", "")),
+                QStandardItem(d.get("town", "")),
+            ]
+            for item in items:
+                item.setEditable(False)
+            self.details_model.appendRow(items)
+


### PR DESCRIPTION
## Summary
- add functions for applying diffs without logging
- introduce `reapply_log_entry` to re-run an import
- expose reapply capability in controller
- show log details below the log table and allow re-apply action

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6853ae62b4f88320ad8ef79cf1661fb7