### PR TITLE
Enhance log details UI and add confirmations

### DIFF
--- a/japanpost_backend/models.py
+++ b/japanpost_backend/models.py
@@ -23,5 +23,10 @@ def create_log_entry(source_file: str, file_type: str, records: List[Dict], url:
         "timestamp": __import__('datetime').datetime.now().isoformat(),
         "record_count": len(records),
         "download_url": url,
-        "details": [{"zipcode": r["zipcode"], "pref": r["pref"], "town": r["town"]} for r in records]
+        "details": [{
+            "zipcode": r["zipcode"],
+            "pref": r["pref"],
+            "city": r.get("city", ""),
+            "town": r["town"]
+        } for r in records]
     }

--- a/japanpost_backend/reverse_patch.py
+++ b/japanpost_backend/reverse_patch.py
@@ -27,7 +27,7 @@ def reverse_log_entry(index: int) -> str:
             records.append({
                 "zipcode": r["zipcode"],
                 "pref": r["pref"],
-                "city": "",  # 必要なら補完。今回は町レベルで登録
+                "city": r.get("city", ""),  # ログに市区町村があれば使用
                 "town": r["town"],
                 "kana": {"pref": "", "city": "", "town": ""},
                 "custom": {}

--- a/ui_main.py
+++ b/ui_main.py
@@ -278,22 +278,43 @@ class MainWindow(QMainWindow):
         indices = self._selected_log_indices()
         if not indices:
             return
-        msg = self.controller.reverse_logs(indices)
-        self.output.append(msg)
-        self.load_logs_page(self.log_current_page)
+        reply = QMessageBox.question(
+            self,
+            "確認",
+            f"{len(indices)} 件の履歴を復元しますか？",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            msg = self.controller.reverse_logs(indices)
+            self.output.append(msg)
+            self.load_logs_page(self.log_current_page)
 
     def delete_selected_logs(self):
         indices = self._selected_log_indices()
         if not indices:
             return
-        msg = self.controller.delete_logs(indices)
-        self.output.append(msg)
-        self.load_logs_page(self.log_current_page)
+        reply = QMessageBox.question(
+            self,
+            "確認",
+            f"{len(indices)} 件の履歴を削除しますか？",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            msg = self.controller.delete_logs(indices)
+            self.output.append(msg)
+            self.load_logs_page(self.log_current_page)
 
     def reapply_selected_logs(self):
         indices = self._selected_log_indices()
         if not indices:
             return
-        msg = self.controller.reapply_logs(indices)
-        self.output.append(msg)
-        self.load_logs_page(self.log_current_page)
+        reply = QMessageBox.question(
+            self,
+            "確認",
+            f"{len(indices)} 件の履歴を再実行しますか？",
+            QMessageBox.Yes | QMessageBox.No,
+        )
+        if reply == QMessageBox.Yes:
+            msg = self.controller.reapply_logs(indices)
+            self.output.append(msg)
+            self.load_logs_page(self.log_current_page)

--- a/views/logs_page.py
+++ b/views/logs_page.py
@@ -11,6 +11,9 @@ class LogsPage(QWidget):
         super().__init__()
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("差分取込履歴"))
+        layout.addWidget(QLabel(
+            "一覧から履歴を選択し、下のボタンで復元・再実行・削除できます。"
+        ))
 
         self.model = QStandardItemModel(0, 5)
         self.model.setHorizontalHeaderLabels([
@@ -26,8 +29,10 @@ class LogsPage(QWidget):
         self.table.clicked.connect(self._display_details)
         layout.addWidget(self.table, 1)
 
-        self.details_model = QStandardItemModel(0, 3)
-        self.details_model.setHorizontalHeaderLabels(["郵便番号", "都道府県", "町域"])
+        self.details_model = QStandardItemModel(0, 4)
+        self.details_model.setHorizontalHeaderLabels([
+            "郵便番号", "都道府県", "市区町村", "町域"
+        ])
         self.details_table = QTableView()
         self.details_table.setModel(self.details_model)
         d_header = self.details_table.horizontalHeader()
@@ -63,7 +68,10 @@ class LogsPage(QWidget):
             return
         log = self.logs[row]
         details = log.get("details", [])
-        detail_lines = [f"{d.get('zipcode', '')} {d.get('pref', '')} {d.get('town', '')}" for d in details]
+        detail_lines = [
+            f"{d.get('zipcode', '')} {d.get('pref', '')} {d.get('city', '')} {d.get('town', '')}"
+            for d in details
+        ]
         text = "\n".join(detail_lines) if detail_lines else "(詳細なし)"
         QMessageBox.information(self, "詳細", text)
 
@@ -77,6 +85,7 @@ class LogsPage(QWidget):
             items = [
                 QStandardItem(d.get("zipcode", "")),
                 QStandardItem(d.get("pref", "")),
+                QStandardItem(d.get("city", "")),
                 QStandardItem(d.get("town", "")),
             ]
             for item in items:


### PR DESCRIPTION
## Summary
- add city information to log entry details
- restore city during log reversal
- show basic instructions on the log page
- display city in log detail view
- ask for confirmation before executing log actions

## Testing
- `python -m py_compile japanpost_backend/models.py japanpost_backend/reverse_patch.py views/logs_page.py ui_main.py`

------
https://chatgpt.com/codex/tasks/task_e_6853b6289a3883209039fb101948713f