### PR TITLE
Add pytest-based backend tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import importlib
+from pathlib import Path
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+@pytest.fixture
+def temp_env(tmp_path, monkeypatch):
+    """Prepare isolated working directory and helper to reload modules."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "resources").mkdir()
+    monkeypatch.syspath_prepend(str(REPO_ROOT))
+
+    def reload_module(name: str):
+        module = importlib.import_module(name)
+        return importlib.reload(module)
+
+    env = {
+        "tmp_path": tmp_path,
+        "resources": tmp_path / "resources",
+        "reload": reload_module,
+    }
+    return env

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,35 @@
+import csv
+import io
+import zipfile
+
+
+def create_zip(path, rows):
+    with zipfile.ZipFile(path, "w") as z:
+        buf = io.StringIO()
+        writer = csv.writer(buf, lineterminator="\n")
+        writer.writerows(rows)
+        z.writestr("data.csv", buf.getvalue())
+
+
+def test_load_csv_from_zip(temp_env):
+    env = temp_env
+    loader = env["reload"]("japanpost_backend.data_loader")
+    row1 = [
+        "13101", "1000001", "1000001",
+        "トウキョウト", "チヨダク", "イチバンチョウ",
+        "東京都", "千代田区", "一番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    row2 = [
+        "13101", "1000002", "1000002",
+        "トウキョウト", "チヨダク", "ニバンチョウ",
+        "東京都", "千代田区", "二番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    zip_path = env["tmp_path"] / "sample.zip"
+    create_zip(zip_path, [row1, row2])
+
+    records = loader.load_csv_from_zip(str(zip_path))
+    assert len(records) == 2
+    assert records[0]["zipcode"] == "1000001"
+    assert records[1]["town"] == "二番町"

--- a/tests/test_db_and_search.py
+++ b/tests/test_db_and_search.py
@@ -1,0 +1,36 @@
+
+def sample_records(models):
+    row1 = [
+        "13101", "1000001", "1000001",
+        "トウキョウト", "チヨダク", "イチバンチョウ",
+        "東京都", "千代田区", "一番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    row2 = [
+        "13101", "1000002", "1000002",
+        "トウキョウト", "チヨダク", "ニバンチョウ",
+        "東京都", "千代田区", "二番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    return [models.create_address_entry(row1), models.create_address_entry(row2)]
+
+
+def test_db_operations_and_search(temp_env):
+    env = temp_env
+    db_manager = env["reload"]("japanpost_backend.db_manager")
+    search_manager = env["reload"]("japanpost_backend.search_manager")
+    models = env["reload"]("japanpost_backend.models")
+
+    records = sample_records(models)
+    db_manager.insert_all(records)
+    assert db_manager.count_records() == 2
+
+    results, total = search_manager.search_with_filters(zipcode="1000001")
+    assert total == 1
+    assert results[0]["town"] == "一番町"
+
+    db_manager.remove_by_zipcode("1000002")
+    assert db_manager.count_records() == 1
+
+    db_manager.clear_all()
+    assert db_manager.count_records() == 0

--- a/tests/test_file_fetcher.py
+++ b/tests/test_file_fetcher.py
@@ -1,0 +1,29 @@
+import os
+import zipfile
+from io import BytesIO
+
+
+def test_download_zip(temp_env, monkeypatch):
+    env = temp_env
+    fetcher = env["reload"]("japanpost_backend.file_fetcher")
+
+    data = BytesIO()
+    with zipfile.ZipFile(data, "w") as z:
+        z.writestr("dummy.txt", "hello")
+    content = data.getvalue()
+
+    class DummyResp:
+        def __init__(self, data):
+            self.content = data
+        def raise_for_status(self):
+            pass
+
+    def fake_get(url, timeout=30):
+        return DummyResp(content)
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+
+    path = fetcher.download_zip("http://example.com/test.zip")
+    assert os.path.basename(path) == "test.zip"
+    assert os.path.exists(path)
+    assert zipfile.is_zipfile(path)

--- a/tests/test_log_and_patch.py
+++ b/tests/test_log_and_patch.py
@@ -1,0 +1,72 @@
+import csv
+import io
+import zipfile
+
+
+def create_zip(path, rows):
+    with zipfile.ZipFile(path, "w") as z:
+        buf = io.StringIO()
+        writer = csv.writer(buf, lineterminator="\n")
+        writer.writerows(rows)
+        z.writestr("data.csv", buf.getvalue())
+
+
+def sample_rows():
+    row1 = [
+        "13101", "1000001", "1000001",
+        "トウキョウト", "チヨダク", "イチバンチョウ",
+        "東京都", "千代田区", "一番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    row2 = [
+        "13101", "1000002", "1000002",
+        "トウキョウト", "チヨダク", "ニバンチョウ",
+        "東京都", "千代田区", "二番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    return row1, row2
+
+
+def test_reverse_and_reapply(temp_env):
+    env = temp_env
+    db_manager = env["reload"]("japanpost_backend.db_manager")
+    log_manager = env["reload"]("japanpost_backend.log_manager")
+    reverse_patch = env["reload"]("japanpost_backend.reverse_patch")
+    reapply_patch = env["reload"]("japanpost_backend.reapply_patch")
+    models = env["reload"]("japanpost_backend.models")
+
+    row1, row2 = sample_rows()
+    rec1 = models.create_address_entry(row1)
+    rec2 = models.create_address_entry(row2)
+
+    add_zip = env["resources"] / "add.zip"
+    del_zip = env["resources"] / "del.zip"
+    create_zip(add_zip, [row1])
+    create_zip(del_zip, [row2])
+
+    logs = [
+        models.create_log_entry("add.zip", "add", [rec1], ""),
+        models.create_log_entry("del.zip", "del", [rec2], ""),
+    ]
+    log_manager.save_logs(logs)
+
+    db_manager.insert_all([rec1])
+
+    msg1 = reverse_patch.reverse_log_entry(0)
+    assert "取り消しました" in msg1
+    assert db_manager.count_records() == 0
+
+    msg2 = reverse_patch.reverse_log_entry(1)
+    assert "復元しました" in msg2
+    assert db_manager.count_records() == 1
+    assert db_manager.get_all()[0]["zipcode"] == rec2["zipcode"]
+
+    db_manager.clear_all()
+
+    msg3 = reapply_patch.reapply_log_entry(0)
+    assert "再実行しました" in msg3
+    assert db_manager.count_records() == 1
+
+    msg4 = reapply_patch.reapply_log_entry(1)
+    assert "再実行しました" in msg4
+    assert db_manager.count_records() == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,28 @@
+
+def test_create_address_entry(temp_env):
+    models = temp_env["reload"]("japanpost_backend.models")
+    row = [
+        "13101", "1000001", "1000001",
+        "トウキョウト", "チヨダク", "イチバンチョウ",
+        "東京都", "千代田区", "一番町",
+        "0", "0", "0", "0", "0", "0",
+    ]
+    addr = models.create_address_entry(row)
+    assert addr["zipcode"] == "1000001"
+    assert addr["pref"] == "東京都"
+    assert addr["city"] == "千代田区"
+    assert addr["town"] == "一番町"
+    assert addr["kana"]["pref"] == "トウキョウト"
+
+
+def test_create_log_entry(temp_env):
+    models = temp_env["reload"]("japanpost_backend.models")
+    records = [
+        {"zipcode": "1000001", "pref": "東京都", "city": "千代田区", "town": "一番町"}
+    ]
+    log = models.create_log_entry("src.zip", "add", records, "http://example.com/src.zip")
+    assert log["source_file"] == "src.zip"
+    assert log["type"] == "add"
+    assert log["record_count"] == 1
+    assert len(log["details"]) == 1
+    assert log["details"][0]["zipcode"] == "1000001"


### PR DESCRIPTION
## Summary
- add unit tests for backend modules using pytest
- include helpers for isolated temporary environments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542193ba6483209bd3c6c05540207d