### PR TITLE
Implement custom field editing

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -5,6 +5,7 @@ from japanpost_backend.diff_applier import (
 )
 from japanpost_backend.reapply_patch import reapply_log_entry
 from japanpost_backend.db_manager import get_all, clear_all, count_records
+from japanpost_backend.db_manager import update_custom
 from japanpost_backend.search_manager import search_with_filters
 from japanpost_backend.log_manager import get_logs, delete_log
 from japanpost_backend.reverse_patch import reverse_log_entry
@@ -79,4 +80,11 @@ class Controller:
         for idx in sorted(indices):
             msgs.append(reapply_log_entry(idx))
         return "\n".join(msgs)
+
+    # --- custom field handling ---
+    def update_custom_fields(self, zipcodes, custom):
+        """Apply the same custom dict to multiple records."""
+        for zc in zipcodes:
+            update_custom(zc, custom)
+        return f"[OK] カスタム項目を更新しました ({len(zipcodes)} 件)"
 

--- a/japanpost_backend/db_manager.py
+++ b/japanpost_backend/db_manager.py
@@ -37,6 +37,12 @@ def get_all() -> List[Dict]:
     return db.all()
 
 
+def get_by_zipcode(zipcode: str) -> Dict:
+    """Return first record matching the zip code or None."""
+    result = db.search(Address.zipcode == zipcode)
+    return result[0] if result else None
+
+
 def count_records() -> int:
     """Return the number of address records."""
     return len(db)

--- a/tests/test_custom_update.py
+++ b/tests/test_custom_update.py
@@ -1,0 +1,16 @@
+def test_update_custom_fields(temp_env):
+    env = temp_env
+    ctrl = env["reload"]("controller").Controller()
+    db = env["reload"]("japanpost_backend.db_manager")
+    m = env["reload"]("japanpost_backend.models")
+    recs = [m.create_address_entry([
+        "13101", "1000001", "1000001",
+        "トウキョウト", "チヨダク", "イチバンチョウ",
+        "東京都", "千代田区", "一番町",
+        "0", "0", "0", "0", "0", "0",
+    ])]
+    db.insert_all(recs)
+    msg = ctrl.update_custom_fields(["1000001"], {"メモ": "test"})
+    assert "更新" in msg
+    rec = db.get_by_zipcode("1000001")
+    assert rec["custom"]["メモ"] == "test"

--- a/views/custom_dialog.py
+++ b/views/custom_dialog.py
@@ -1,0 +1,99 @@
+from PySide6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QTreeWidget,
+    QTreeWidgetItem, QLabel
+)
+from PySide6.QtCore import Qt
+
+
+class CustomEditDialog(QDialog):
+    """Dialog to input nested custom data."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("カスタム項目追加")
+        layout = QVBoxLayout(self)
+
+        self.tree = QTreeWidget()
+        self.tree.setColumnCount(2)
+        self.tree.setHeaderLabels(["キー", "値"])
+        layout.addWidget(self.tree)
+
+        btns = QHBoxLayout()
+        self.add_btn = QPushButton("＋")
+        self.add_child_btn = QPushButton("＋子")
+        self.remove_btn = QPushButton("－")
+        btns.addWidget(self.add_btn)
+        btns.addWidget(self.add_child_btn)
+        btns.addWidget(self.remove_btn)
+        btns.addStretch()
+        layout.addLayout(btns)
+
+        action = QHBoxLayout()
+        self.ok_btn = QPushButton("決定")
+        self.cancel_btn = QPushButton("キャンセル")
+        action.addWidget(self.ok_btn)
+        action.addWidget(self.cancel_btn)
+        action.addStretch()
+        layout.addLayout(action)
+
+        self.add_btn.clicked.connect(self.add_root_item)
+        self.add_child_btn.clicked.connect(self.add_child_item)
+        self.remove_btn.clicked.connect(self.remove_item)
+        self.ok_btn.clicked.connect(self.accept)
+        self.cancel_btn.clicked.connect(self.reject)
+
+    # --- button handlers ---
+    def add_root_item(self):
+        item = QTreeWidgetItem(["key", "value"])
+        item.setFlags(item.flags() | Qt.ItemIsEditable)
+        self.tree.addTopLevelItem(item)
+
+    def add_child_item(self):
+        current = self.tree.currentItem()
+        if not current:
+            return
+        child = QTreeWidgetItem(["key", "value"])
+        child.setFlags(child.flags() | Qt.ItemIsEditable)
+        current.addChild(child)
+        current.setExpanded(True)
+
+    def remove_item(self):
+        current = self.tree.currentItem()
+        if not current:
+            return
+        parent = current.parent()
+        if parent:
+            parent.removeChild(current)
+        else:
+            idx = self.tree.indexOfTopLevelItem(current)
+            if idx >= 0:
+                self.tree.takeTopLevelItem(idx)
+
+    # --- data retrieval ---
+    def get_data(self):
+        result = {}
+        for i in range(self.tree.topLevelItemCount()):
+            key, val = self._build_dict(self.tree.topLevelItem(i))
+            if key in result:
+                if not isinstance(result[key], list):
+                    result[key] = [result[key]]
+                result[key].append(val)
+            else:
+                result[key] = val
+        return result
+
+    def _build_dict(self, item):
+        if item.childCount() > 0:
+            d = {}
+            for i in range(item.childCount()):
+                k, v = self._build_dict(item.child(i))
+                if k in d:
+                    if not isinstance(d[k], list):
+                        d[k] = [d[k]]
+                    d[k].append(v)
+                else:
+                    d[k] = v
+            return item.text(0), d
+        else:
+            return item.text(0), item.text(1)
+

--- a/views/search_page.py
+++ b/views/search_page.py
@@ -34,12 +34,17 @@ class SearchPage(QWidget):
         self.table = QTableView()
         layout.addWidget(self.table, 1)
 
+        self.add_custom_btn = QPushButton("項目を追加")
+        self.add_custom_btn.setEnabled(False)
+        layout.addWidget(self.add_custom_btn)
+
         self.no_results_label = QLabel("")
         layout.addWidget(self.no_results_label)
 
-        self.model = QStandardItemModel(0, 4)
-        self.model.setHorizontalHeaderLabels(["郵便番号", "都道府県", "市区町村", "町域"])
+        self.model = QStandardItemModel(0, 5)
+        self.model.setHorizontalHeaderLabels(["選択", "郵便番号", "都道府県", "市区町村", "町域"])
         self.table.setModel(self.model)
+        self.model.itemChanged.connect(self._update_button_state)
 
         pager = QHBoxLayout()
         self.prev_btn = QPushButton("前へ")
@@ -52,3 +57,20 @@ class SearchPage(QWidget):
 
         self.current_page = 1
         self.total_pages = 1
+
+    def _update_button_state(self, *args):
+        selected = False
+        for row in range(self.model.rowCount()):
+            item = self.model.item(row, 0)
+            if item.checkState() == Qt.Checked:
+                selected = True
+                break
+        self.add_custom_btn.setEnabled(selected)
+
+    def selected_zipcodes(self):
+        zips = []
+        for row in range(self.model.rowCount()):
+            item = self.model.item(row, 0)
+            if item.checkState() == Qt.Checked:
+                zips.append(self.model.item(row, 1).text())
+        return zips


### PR DESCRIPTION
## Summary
- add `CustomEditDialog` for nested custom data
- enable selecting addresses and adding custom fields
- update controller and db manager
- include regression test for custom field updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685431b01f148320b8910bf5f94a0b62