### PR TITLE
Switch tables to row selection

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -214,13 +214,11 @@ class MainWindow(QMainWindow):
 
         self.search_page.model.removeRows(0, self.search_page.model.rowCount())
         for zipcode, pref, city, town in records:
-            check_item = QStandardItem()
-            check_item.setCheckable(True)
-            check_item.setEditable(False)
-            row_items = [check_item] + [QStandardItem(x) for x in [zipcode, pref, city, town]]
-            for item in row_items[1:]:
+            row_items = [QStandardItem(x) for x in [zipcode, pref, city, town]]
+            for item in row_items:
                 item.setEditable(False)
             self.search_page.model.appendRow(row_items)
+        self.search_page.table.clearSelection()
         self.search_page._update_button_state()
 
         if total == 0:
@@ -278,10 +276,8 @@ class MainWindow(QMainWindow):
 
         self.logs_page.model.removeRows(0, self.logs_page.model.rowCount())
         for log in logs:
-            check_item = QStandardItem()
-            check_item.setCheckable(True)
-            check_item.setData(log["index"], Qt.UserRole)
             type_item = QStandardItem("追加" if log["type"] == "add" else "削除")
+            type_item.setData(log["index"], Qt.UserRole)
             file_item = QStandardItem(log.get("source_file", ""))
             count_item = QStandardItem(str(log.get("record_count", 0)))
             ts = log.get("timestamp", "")
@@ -290,9 +286,10 @@ class MainWindow(QMainWindow):
             except Exception:
                 pass
             ts_item = QStandardItem(ts)
-            for item in [check_item, type_item, file_item, count_item, ts_item]:
+            for item in [type_item, file_item, count_item, ts_item]:
                 item.setEditable(False)
-            self.logs_page.model.appendRow([check_item, type_item, file_item, count_item, ts_item])
+            self.logs_page.model.appendRow([type_item, file_item, count_item, ts_item])
+        self.logs_page.table.clearSelection()
 
         self.log_current_page = page
         self.log_total_pages = max(1, (total + 29) // 30)
@@ -302,11 +299,10 @@ class MainWindow(QMainWindow):
 
     def _selected_log_indices(self):
         indices = []
-        for row in range(self.logs_page.model.rowCount()):
-            item = self.logs_page.model.item(row, 0)
-            if item.checkState() == Qt.Checked:
-                idx = item.data(Qt.UserRole)
-                indices.append(idx)
+        for index in self.logs_page.table.selectionModel().selectedRows():
+            item = self.logs_page.model.item(index.row(), 0)
+            idx = item.data(Qt.UserRole)
+            indices.append(idx)
         return indices
 
     def restore_selected_logs(self):

--- a/views/logs_page.py
+++ b/views/logs_page.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QHBoxLayout,
-    QPushButton, QTableView, QMessageBox, QHeaderView
+    QPushButton, QTableView, QMessageBox, QHeaderView, QAbstractItemView
 )
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QStandardItemModel, QStandardItem
@@ -15,16 +15,18 @@ class LogsPage(QWidget):
             "一覧から履歴を選択し、下のボタンで復元・再実行・削除できます。"
         ))
 
-        self.model = QStandardItemModel(0, 5)
+        self.model = QStandardItemModel(0, 4)
         self.model.setHorizontalHeaderLabels([
-            "選択", "種別", "ファイル", "件数", "日時"
+            "種別", "ファイル", "件数", "日時"
         ])
         self.table = QTableView()
         self.table.setModel(self.model)
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.MultiSelection)
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeToContents)
-        self.table.setColumnWidth(2, 250)
-        self.table.setColumnWidth(4, 150)
+        self.table.setColumnWidth(1, 250)
+        self.table.setColumnWidth(3, 150)
         self.table.doubleClicked.connect(self._show_details)
         self.table.clicked.connect(self._display_details)
         layout.addWidget(self.table, 1)

--- a/views/search_page.py
+++ b/views/search_page.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QHBoxLayout, QLineEdit,
-    QPushButton, QTableView
+    QPushButton, QTableView, QAbstractItemView
 )
 from PySide6.QtCore import Qt, QRegularExpression
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QRegularExpressionValidator
@@ -32,6 +32,8 @@ class SearchPage(QWidget):
         layout.addLayout(form)
 
         self.table = QTableView()
+        self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
+        self.table.setSelectionMode(QAbstractItemView.MultiSelection)
         layout.addWidget(self.table, 1)
 
         self.add_custom_btn = QPushButton("項目を追加")
@@ -41,10 +43,10 @@ class SearchPage(QWidget):
         self.no_results_label = QLabel("")
         layout.addWidget(self.no_results_label)
 
-        self.model = QStandardItemModel(0, 5)
-        self.model.setHorizontalHeaderLabels(["選択", "郵便番号", "都道府県", "市区町村", "町域"])
+        self.model = QStandardItemModel(0, 4)
+        self.model.setHorizontalHeaderLabels(["郵便番号", "都道府県", "市区町村", "町域"])
         self.table.setModel(self.model)
-        self.model.itemChanged.connect(self._update_button_state)
+        self.table.selectionModel().selectionChanged.connect(self._update_button_state)
 
         pager = QHBoxLayout()
         self.prev_btn = QPushButton("前へ")
@@ -59,18 +61,11 @@ class SearchPage(QWidget):
         self.total_pages = 1
 
     def _update_button_state(self, *args):
-        selected = False
-        for row in range(self.model.rowCount()):
-            item = self.model.item(row, 0)
-            if item.checkState() == Qt.Checked:
-                selected = True
-                break
+        selected = bool(self.table.selectionModel().selectedRows())
         self.add_custom_btn.setEnabled(selected)
 
     def selected_zipcodes(self):
         zips = []
-        for row in range(self.model.rowCount()):
-            item = self.model.item(row, 0)
-            if item.checkState() == Qt.Checked:
-                zips.append(self.model.item(row, 1).text())
+        for index in self.table.selectionModel().selectedRows():
+            zips.append(self.model.item(index.row(), 0).text())
         return zips


### PR DESCRIPTION
## Summary
- use row selection instead of check boxes in search and log tables
- keep multi-selection functionality

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68543a54ab5883208421d8132d7ed846