### PR TITLE
Implement record-wise custom edit navigation

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -4,8 +4,10 @@ from japanpost_backend.diff_applier import (
     apply_add_zip, apply_del_zip,
 )
 from japanpost_backend.reapply_patch import reapply_log_entry
-from japanpost_backend.db_manager import get_all, clear_all, count_records
-from japanpost_backend.db_manager import update_custom
+from japanpost_backend.db_manager import (
+    get_all, clear_all, count_records,
+    update_custom, get_by_zipcode,
+)
 from japanpost_backend.search_manager import search_with_filters
 from japanpost_backend.log_manager import get_logs, delete_log
 from japanpost_backend.reverse_patch import reverse_log_entry
@@ -59,6 +61,10 @@ class Controller:
         """Return number of records in the database."""
         return count_records()
 
+    def get_record(self, zipcode: str):
+        """Return a single record by zipcode or None."""
+        return get_by_zipcode(zipcode)
+
     # --- log handling ---
     def fetch_logs(self, page: int = 1, per_page: int = 30):
         """Return paginated import logs and total count."""
@@ -87,4 +93,10 @@ class Controller:
         for zc in zipcodes:
             update_custom(zc, custom)
         return f"[OK] カスタム項目を更新しました ({len(zipcodes)} 件)"
+
+    def update_custom_map(self, mapping):
+        """Apply different custom dicts for multiple records."""
+        for zc, custom in mapping.items():
+            update_custom(zc, custom)
+        return f"[OK] カスタム項目を更新しました ({len(mapping)} 件)"
 

--- a/tests/test_custom_update.py
+++ b/tests/test_custom_update.py
@@ -14,3 +14,21 @@ def test_update_custom_fields(temp_env):
     assert "更新" in msg
     rec = db.get_by_zipcode("1000001")
     assert rec["custom"]["メモ"] == "test"
+
+
+def test_update_custom_map(temp_env):
+    env = temp_env
+    ctrl = env["reload"]("controller").Controller()
+    db = env["reload"]("japanpost_backend.db_manager")
+    m = env["reload"]("japanpost_backend.models")
+    recs = [m.create_address_entry([
+        "13101", "1000001", "1000001",
+        "トウキョウト", "チヨダク", "イチバンチョウ",
+        "東京都", "千代田区", "一番町",
+        "0", "0", "0", "0", "0", "0",
+    ])]
+    db.insert_all(recs)
+    msg = ctrl.update_custom_map({"1000001": {"タグ": "a"}})
+    assert "更新" in msg
+    rec = db.get_by_zipcode("1000001")
+    assert rec["custom"]["タグ"] == "a"

--- a/ui_main.py
+++ b/ui_main.py
@@ -245,8 +245,12 @@ class MainWindow(QMainWindow):
         selected = self.search_page.selected_zipcodes()
         if not selected:
             return
+        records = {}
+        for zc in selected:
+            rec = self.controller.get_record(zc)
+            records[zc] = rec.get("custom", {}) if rec else {}
         self._pending_zipcodes = selected
-        self.custom_page.tree.clear()
+        self.custom_page.setup_records(records)
         self.stack.setCurrentWidget(self.custom_page)
 
     def _custom_page_accepted(self, data):
@@ -257,7 +261,7 @@ class MainWindow(QMainWindow):
             QMessageBox.Yes | QMessageBox.No,
         )
         if reply == QMessageBox.Yes:
-            msg = self.controller.update_custom_fields(self._pending_zipcodes, data)
+            msg = self.controller.update_custom_map(data)
             self.output.append(msg)
             self.perform_search(self.current_page)
         self.stack.setCurrentWidget(self.search_page)


### PR DESCRIPTION
## Summary
- allow controller to fetch individual records
- support updating custom fields with a mapping per zipcode
- enhance custom edit page with record navigation and multiple-edit state
- initialize custom edit page with existing custom data from search results
- test update_custom_map feature

## Testing
- `pip install -q tinydb requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e121532883209895eb325eb72472