### PR TITLE
Support multiple search filters with dynamic fields

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -8,7 +8,7 @@ from japanpost_backend.db_manager import (
     get_all, clear_all, count_records,
     update_custom, get_by_zipcode,
 )
-from japanpost_backend.search_manager import search_with_filters
+from japanpost_backend.search_manager import search_with_filters, search_multiple
 from japanpost_backend.log_manager import get_logs, delete_log
 from japanpost_backend.reverse_patch import reverse_log_entry
 
@@ -43,9 +43,13 @@ class Controller:
         return [(r["zipcode"], r["pref"], r["city"], r["town"]) for r in records]
 
     def search_addresses(self, zipcode: str = "", pref: str = "", city: str = "",
-                         town: str = "", page: int = 1, per_page: int = 30):
-        results, total = search_with_filters(zipcode, pref, city, town,
-                                            page, per_page)
+                         town: str = "", page: int = 1, per_page: int = 30,
+                         filters=None):
+        if filters is not None:
+            results, total = search_multiple(filters, page, per_page)
+        else:
+            results, total = search_with_filters(zipcode, pref, city, town,
+                                                page, per_page)
         data = [(r["zipcode"], r["pref"], r["city"], r["town"]) for r in results]
         return data, total
 

--- a/japanpost_backend/search_manager.py
+++ b/japanpost_backend/search_manager.py
@@ -49,3 +49,28 @@ def search_with_filters(
     start = max(page - 1, 0) * per_page
     end = start + per_page
     return matched[start:end], total
+
+
+def search_multiple(filters: List[Dict], page: int = 1, per_page: int = 30) -> Tuple[List[Dict], int]:
+    """Search using multiple sets of filters and return combined results."""
+    combined = []
+    for f in filters:
+        z = f.get("zipcode", "")
+        p = f.get("pref", "")
+        c = f.get("city", "")
+        t = f.get("town", "")
+        results, _ = search_with_filters(z, p, c, t, page=1, per_page=len(db))
+        combined.extend(results)
+
+    unique = []
+    seen = set()
+    for r in combined:
+        key = (r.get("zipcode"), r.get("pref"), r.get("city"), r.get("town"))
+        if key not in seen:
+            seen.add(key)
+            unique.append(r)
+
+    total = len(unique)
+    start = max(page - 1, 0) * per_page
+    end = start + per_page
+    return unique[start:end], total

--- a/tests/test_db_and_search.py
+++ b/tests/test_db_and_search.py
@@ -34,3 +34,23 @@ def test_db_operations_and_search(temp_env):
 
     db_manager.clear_all()
     assert db_manager.count_records() == 0
+
+
+def test_search_multiple(temp_env):
+    env = temp_env
+    db_manager = env["reload"]("japanpost_backend.db_manager")
+    search_manager = env["reload"]("japanpost_backend.search_manager")
+    models = env["reload"]("japanpost_backend.models")
+
+    records = sample_records(models)
+    db_manager.insert_all(records)
+
+    filters = [
+        {"zipcode": "1000001"},
+        {"town": "二番町"},
+    ]
+
+    results, total = search_manager.search_multiple(filters)
+    assert total == 2
+    towns = sorted([r["town"] for r in results])
+    assert towns == ["一番町", "二番町"]

--- a/ui_main.py
+++ b/ui_main.py
@@ -205,12 +205,9 @@ class MainWindow(QMainWindow):
 
     # --- 検索関連処理 ---
     def perform_search(self, page: int = 1):
-        zipcode = self.search_page.zip_input.text().strip()
-        pref = self.search_page.pref_input.text().strip()
-        city = self.search_page.city_input.text().strip()
-        town = self.search_page.town_input.text().strip()
+        filters = self.search_page.get_filters()
         records, total = self.controller.search_addresses(
-            zipcode, pref, city, town, page, per_page=30)
+            page=page, per_page=30, filters=filters)
 
         self.search_page.model.removeRows(0, self.search_page.model.rowCount())
         for zipcode, pref, city, town in records:


### PR DESCRIPTION
## Summary
- allow Controller to perform search with multiple filter sets
- implement `search_multiple` in backend to merge results from several criteria
- update SearchPage UI with add/remove rows for additional search criteria
- query backend with new filters in MainWindow
- test new search functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68553e5689008320b1f5956dbeaf2999