### PR TITLE
Fix indentation errors in GUI views

### DIFF
--- a/views/custom_dialog.py
+++ b/views/custom_dialog.py
@@ -5,10 +5,10 @@ from PySide6.QtWidgets import (
     QTreeWidgetItem, QLabel
 )
 from PySide6.QtCore import Qt
-class CustomEditDialog(QDialog):
-    """ネストしたカスタムデータを入力するダイアログ"""
+
 
 class CustomEditDialog(QDialog):
+    """ネストしたカスタムデータを入力するダイアログ"""
     """Dialog to input nested custom data."""
 
     def __init__(self, parent=None):

--- a/views/custom_page.py
+++ b/views/custom_page.py
@@ -5,10 +5,10 @@ from PySide6.QtWidgets import (
     QTreeWidgetItem, QLabel
 )
 from PySide6.QtCore import Qt, Signal
-class CustomEditPage(QWidget):
-    """ネストしたカスタムデータを入力するページ"""
+
 
 class CustomEditPage(QWidget):
+    """ネストしたカスタムデータを入力するページ"""
     """Page to input nested custom data."""
 
     accepted = Signal(dict)

--- a/views/register_page.py
+++ b/views/register_page.py
@@ -3,6 +3,7 @@
 from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QLineEdit, QPushButton
 
 
+class RegisterPage(QWidget):
     """住所データ処理を行う汎用ページ"""
     """Generic page for executing address data operations."""
 


### PR DESCRIPTION
## Summary
- repair `RegisterPage` class definition
- fix duplicate class definitions in `CustomEditPage` and `CustomEditDialog`
- keep Japanese/English comments intact

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856746630e483209add7e89daa0ed77