### PR TITLE
Improve custom edit navigation and search row limit

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -248,7 +248,15 @@ class MainWindow(QMainWindow):
         records = {}
         for zc in selected:
             rec = self.controller.get_record(zc)
-            records[zc] = rec.get("custom", {}) if rec else {}
+            if rec:
+                records[zc] = {
+                    "pref": rec.get("pref", ""),
+                    "city": rec.get("city", ""),
+                    "town": rec.get("town", ""),
+                    "custom": rec.get("custom", {}),
+                }
+            else:
+                records[zc] = {"pref": "", "city": "", "town": "", "custom": {}}
         self._pending_zipcodes = selected
         self.custom_page.setup_records(records)
         self.stack.setCurrentWidget(self.custom_page)

--- a/views/search_page.py
+++ b/views/search_page.py
@@ -26,6 +26,7 @@ class SearchPage(QWidget):
         add_row_area.addWidget(self.add_row_btn)
         add_row_area.addStretch()
         layout.addLayout(add_row_area)
+        self._update_add_button()
 
         self.search_btn = QPushButton("検索")
         layout.addWidget(self.search_btn)
@@ -81,10 +82,13 @@ class SearchPage(QWidget):
         return row
 
     def _add_row(self):
+        if len(self.rows) >= 4:
+            return
         row = self._create_row()
         self.rows.append(row)
         self.form_container.addLayout(row["layout"])
         self._update_remove_buttons()
+        self._update_add_button()
 
     def _remove_row(self, row):
         if row not in self.rows:
@@ -97,11 +101,15 @@ class SearchPage(QWidget):
                 widget.setParent(None)
         self.form_container.removeItem(row["layout"])
         self._update_remove_buttons()
+        self._update_add_button()
 
     def _update_remove_buttons(self):
         enable = len(self.rows) > 1
         for r in self.rows:
             r["remove"].setEnabled(enable)
+
+    def _update_add_button(self):
+        self.add_row_btn.setEnabled(len(self.rows) < 4)
 
     def get_filters(self):
         filters = []


### PR DESCRIPTION
## Summary
- limit search filters to four rows
- show selected address info on custom edit page
- center custom edit page buttons and unify button width

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68567717da2483208d1d537f0d5768af