### PR TITLE
Improve bulk registration screen UI

### DIFF
--- a/ui_main.py
+++ b/ui_main.py
@@ -58,7 +58,11 @@ class MainWindow(QMainWindow):
         menu_layout.addWidget(self.menu)
 
         # 各ページを作成
-        self.bulk_page = RegisterPage("一括登録", "一括登録 実行")
+        bulk_info = (
+            "日本郵便サイトの『utf_ken_all.zip』URLを入力し実行してください。\n"
+            "既存データは削除され、新しいデータで置き換わります。"
+        )
+        self.bulk_page = RegisterPage("一括登録", "一括登録 実行", instructions=bulk_info)
         self.add_page = RegisterPage("差分追加", "差分追加 実行")
         self.del_page = RegisterPage("差分削除", "差分削除 実行")
         self.clear_page = ClearPage()

--- a/views/register_page.py
+++ b/views/register_page.py
@@ -1,19 +1,48 @@
 # URL を入力して処理を実行するページ
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QLineEdit, QPushButton
+from PySide6.QtWidgets import (
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+)
+from PySide6.QtGui import QFont, QIcon
 
 
 class RegisterPage(QWidget):
     """住所データ処理を行う汎用ページ"""
     """Generic page for executing address data operations."""
 
-    def __init__(self, label: str, button_label: str):
+    def __init__(self, label: str, button_label: str, instructions: str = "", icon_name: str = "system-run"):
         super().__init__()
+
         self.url_input = QLineEdit()
 
         layout = QVBoxLayout(self)
-        layout.addWidget(QLabel(f"{label}用 URL"))
+
+        title = QLabel(f"{label}用 URL")
+        title_font = QFont()
+        title_font.setPointSize(title.font().pointSize() + 2)
+        title.setFont(title_font)
+        layout.addWidget(title)
+
+        input_font = QFont()
+        input_font.setPointSize(self.url_input.font().pointSize() + 2)
+        self.url_input.setFont(input_font)
+        self.url_input.setFixedHeight(36)
         layout.addWidget(self.url_input)
+
         self.run_button = QPushButton(button_label)
+        self.run_button.setIcon(QIcon.fromTheme(icon_name))
+        self.run_button.setFont(input_font)
+        self.run_button.setFixedHeight(40)
         layout.addWidget(self.run_button)
+
         layout.addStretch()
+
+        if instructions:
+            info = QLabel(instructions)
+            info.setWordWrap(True)
+            info.setStyleSheet("color: gray;")
+            layout.addWidget(info)


### PR DESCRIPTION
## Summary
- enlarge form font and add optional instructions in RegisterPage
- show usage instructions on the bulk registration page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68567864ef388320b472fa1287ff6e74