### PR TITLE
Fix oversized buttons

### DIFF
--- a/views/clear_page.py
+++ b/views/clear_page.py
@@ -1,6 +1,7 @@
 # 全データ削除を実行するページ
 
-from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton
+from PySide6.QtWidgets import QWidget, QVBoxLayout, QLabel, QPushButton, QSizePolicy
+from PySide6.QtCore import Qt
 
 
 class ClearPage(QWidget):
@@ -12,5 +13,7 @@ class ClearPage(QWidget):
         layout.addWidget(title)
         self.run_button = QPushButton("全削除 実行")
         self.run_button.setObjectName("dangerButton")
-        layout.addWidget(self.run_button)
+        self.run_button.setFixedHeight(40)
+        self.run_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        layout.addWidget(self.run_button, alignment=Qt.AlignCenter)
         layout.addStretch()

--- a/views/custom_page.py
+++ b/views/custom_page.py
@@ -65,14 +65,6 @@ class CustomEditPage(QWidget):
             btns.addWidget(b)
         layout.addLayout(btns)
 
-        # unify button widths
-        width = max(b.sizeHint().width() for b in [self.add_btn, self.remove_btn,
-                                                   self.add_child_btn,
-                                                   self.cancel_btn, self.ok_btn])
-        for b in [self.add_btn, self.remove_btn, self.add_child_btn,
-                  self.cancel_btn, self.ok_btn]:
-            b.setFixedWidth(width)
-
         self.add_btn.clicked.connect(self.add_root_item)
         self.add_child_btn.clicked.connect(self.add_child_item)
         self.remove_btn.clicked.connect(self.remove_item)

--- a/views/register_page.py
+++ b/views/register_page.py
@@ -6,8 +6,10 @@ from PySide6.QtWidgets import (
     QLabel,
     QLineEdit,
     QPushButton,
+    QSizePolicy,
 )
 from PySide6.QtGui import QFont, QIcon
+from PySide6.QtCore import Qt
 
 
 class RegisterPage(QWidget):
@@ -39,7 +41,8 @@ class RegisterPage(QWidget):
         self.run_button.setIcon(QIcon.fromTheme(icon_name))
         self.run_button.setFont(input_font)
         self.run_button.setFixedHeight(40)
-        layout.addWidget(self.run_button)
+        self.run_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        layout.addWidget(self.run_button, alignment=Qt.AlignCenter)
 
         layout.addStretch()
 

--- a/views/search_page.py
+++ b/views/search_page.py
@@ -2,7 +2,7 @@
 
 from PySide6.QtWidgets import (
     QWidget, QVBoxLayout, QLabel, QHBoxLayout, QLineEdit,
-    QPushButton, QTableView, QAbstractItemView
+    QPushButton, QTableView, QAbstractItemView, QSizePolicy
 )
 from PySide6.QtCore import Qt, QRegularExpression
 from PySide6.QtGui import QStandardItemModel, QStandardItem, QRegularExpressionValidator
@@ -34,7 +34,9 @@ class SearchPage(QWidget):
 
         self.search_btn = QPushButton("検索")
         self.search_btn.setObjectName("primaryButton")
-        layout.addWidget(self.search_btn)
+        self.search_btn.setFixedHeight(40)
+        self.search_btn.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        layout.addWidget(self.search_btn, alignment=Qt.AlignCenter)
 
         self.table = QTableView()
         self.table.setSelectionBehavior(QAbstractItemView.SelectRows)
@@ -44,7 +46,9 @@ class SearchPage(QWidget):
         self.add_custom_btn = QPushButton("項目を追加")
         self.add_custom_btn.setObjectName("primaryButton")
         self.add_custom_btn.setEnabled(False)
-        layout.addWidget(self.add_custom_btn)
+        self.add_custom_btn.setFixedHeight(40)
+        self.add_custom_btn.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        layout.addWidget(self.add_custom_btn, alignment=Qt.AlignCenter)
 
         self.no_results_label = QLabel("")
         layout.addWidget(self.no_results_label)


### PR DESCRIPTION
## Summary
- fix alignment/size on run buttons
- center align search buttons
- remove forced uniform width on custom page buttons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856859d092083208dbaa082001f8b04