### PR TITLE
Fix Unicode decode error on Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from ui_main import MainWindow
 def main():
     """GUI を起動するメイン関数"""
     app = QApplication(sys.argv)
-    with open("resources/styles/style.qss") as f:
+    with open("resources/styles/style.qss", encoding="utf-8") as f:
         app.setStyleSheet(app.styleSheet() + f.read())
     window = MainWindow()
     window.showMaximized()


### PR DESCRIPTION
## Summary
- open `style.qss` with explicit UTF-8 encoding to avoid Windows `cp932` decode errors

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569f75ec048320bee412c4d7d0a1b5