### PR TITLE
Update labels and docs for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🇯🇵 日本郵便住所データ管理システム（TinyDB版）
 
 ## 📦 概要
-日本郵便が公開している住所CSVデータ（`utf_ken_all.zip`、`utf_add_YYMM.zip`、`utf_del_YYMM.zip`）を取り込み、ローカルの JSON データベース（TinyDB）で管理するためのデスクトップアプリです。GUI 上から一括登録や差分追加・削除、検索が行えます。
+日本郵便が公開している住所CSVデータ（`utf_ken_all.zip`、`utf_add_YYMM.zip`、`utf_del_YYMM.zip`）を取り込み、ローカルの JSON データベース（TinyDB）で管理するためのデスクトップアプリです。GUI 上から住所データの一括登録や更新データの追加登録・削除、検索が行えます。
 
 ## 🛠 セットアップ
 ### 1. 仮想環境の作成と有効化
@@ -22,8 +22,8 @@ pip install -r requirements.txt
 ### 3. 初期データの配置
 以下の ZIP ファイルを日本郵便公式サイトからダウンロードし、`resources/` フォルダーに配置してください。
 - 全国版: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_ken_all.zip>
-- 差分追加: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_add_YYMM.zip>
-- 差分削除: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_del_YYMM.zip>
+- 追加データ: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_add_YYMM.zip>
+- 削除データ: <https://www.post.japanpost.jp/zipcode/dl/kogaki/zip/utf_del_YYMM.zip>
 
 ### ダウンロードデータのフォーマット
 日本郵便が配布する CSV ファイルは次の順で項目が並んでいます。
@@ -54,9 +54,9 @@ python main.py
 ## 🖥️ 主な機能
 | 機能 | 説明 |
 | --- | --- |
-| 一括登録 | `utf_ken_all.zip` を読み込み全件登録 |
-| 差分追加 | `utf_add_YYMM.zip` の内容を追加登録 |
-| 差分削除 | `utf_del_YYMM.zip` の内容を論理削除 |
+| 📦 全住所データの初期登録 | `utf_ken_all.zip` を読み込み全件登録 |
+| ➕ 更新データの追加登録（新住所） | `utf_add_YYMM.zip` の内容を追加登録 |
+| ➖ 更新データによる削除（削除済住所） | `utf_del_YYMM.zip` の内容を論理削除 |
 | 全削除 | 登録済みの住所データをすべて削除 |
 | 検索 | 郵便番号・都道府県・市区町村・町域でリアルタイム検索 |
 | 詳細検索API | バックエンドで郵便番号・都道府県・市区町村・町域を条件指定して検索 |

--- a/ui_main.py
+++ b/ui_main.py
@@ -42,7 +42,15 @@ class MainWindow(QMainWindow):
         # サイドメニュー
         self.menu_width = 180
         self.menu = QListWidget()
-        self.menu.addItems(["一括登録", "差分追加", "差分削除", "全削除", "検索", "履歴", "jsonデータ"])
+        self.menu.addItems([
+            "住所データ / 一括登録",
+            "データ更新 / 追加",
+            "データ更新 / 削除",
+            "全削除",
+            "検索",
+            "履歴",
+            "JSONのインポート / エクスポート",
+        ])
         self.menu.setFixedWidth(self.menu_width)
         self.menu.currentRowChanged.connect(self.switch_page)
 
@@ -61,16 +69,32 @@ class MainWindow(QMainWindow):
 
         # 各ページを作成
         bulk_info = (
-            "日本郵便サイトの『utf_ken_all.zip』URLを入力し実行してください。\n"
-            "既存データは削除され、新しいデータで置き換わります。"
+            "日本郵便が公開している全住所データ（utf_ken_all.zip）を使って、"
+            "新規または再登録します。"
         )
-        self.bulk_page = RegisterPage("一括登録", "一括登録 実行", instructions=bulk_info)
+        self.bulk_page = RegisterPage(
+            "📦 全住所データの初期登録",
+            "一括登録 実行",
+            instructions=bulk_info,
+        )
 
-        add_info = "日本郵便サイトの『utf_add_YYMM.zip』URLを入力し実行してください。"
-        self.add_page = RegisterPage("差分追加", "差分追加 実行", instructions=add_info)
+        add_info = (
+            "日本郵便が月次で公開する追加データ（utf_add_YYMM.zip）を既存データに加えます。"
+        )
+        self.add_page = RegisterPage(
+            "➕ 更新データの追加登録（新住所）",
+            "差分追加 実行",
+            instructions=add_info,
+        )
 
-        del_info = "日本郵便サイトの『utf_del_YYMM.zip』URLを入力し実行してください。"
-        self.del_page = RegisterPage("差分削除", "差分削除 実行", instructions=del_info)
+        del_info = (
+            "日本郵便の削除データ（utf_del_YYMM.zip）に基づいて、該当の住所を論理削除します。"
+        )
+        self.del_page = RegisterPage(
+            "➖ 更新データによる削除（削除済住所）",
+            "差分削除 実行",
+            instructions=del_info,
+        )
         self.clear_page = ClearPage()
         self.search_page = SearchPage()
         self.logs_page = LogsPage()

--- a/views/clear_page.py
+++ b/views/clear_page.py
@@ -9,11 +9,13 @@ class ClearPage(QWidget):
         super().__init__()
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
-        title = QLabel("登録データを全て削除")
+        title = QLabel("🧹 住所データの全削除")
         title.setObjectName("pageTitle")
         layout.addWidget(title)
 
-        info = QLabel("登録済みの住所データを全て削除します。")
+        info = QLabel(
+            "すべての住所データを削除します（履歴・カスタムデータも対象にするか要確認）。"
+        )
         info.setWordWrap(True)
         info.setStyleSheet("color: gray;")
         layout.addWidget(info)

--- a/views/json_page.py
+++ b/views/json_page.py
@@ -12,9 +12,16 @@ class JsonDataPage(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
 
-        title = QLabel("jsonデータ")
+        title = QLabel("🔄 データの保存・復元")
         title.setObjectName("pageTitle")
         layout.addWidget(title)
+
+        info = QLabel(
+            "住所データや履歴のJSONバックアップとインポートを行います。"
+        )
+        info.setWordWrap(True)
+        info.setStyleSheet("color: gray;")
+        layout.addWidget(info)
 
         import_row = QHBoxLayout()
         import_label = QLabel("データをインポート")

--- a/views/register_page.py
+++ b/views/register_page.py
@@ -24,7 +24,7 @@ class RegisterPage(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
 
-        title = QLabel(f"{label}用 URL")
+        title = QLabel(label)
         title.setObjectName("pageTitle")
         title_font = QFont()
         title_font.setPointSize(24)


### PR DESCRIPTION
## Summary
- update side menu labels for clarity
- update page titles and descriptions
- tweak pages for JSON import/export and data deletion
- adjust register page title behavior
- revise README with unified terminology

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a7d262a883209e4512ff9fed49ec