### PR TITLE
Improve custom edit page

### DIFF
--- a/resources/styles/style.qss
+++ b/resources/styles/style.qss
@@ -99,6 +99,12 @@ QTableView::item:selected {
     color: #1A1A1A;
 }
 
+/* ツリービュー選択時の色 */
+QTreeWidget::item:selected {
+    background-color: #D6E4FF;
+    color: #1A1A1A;
+}
+
 QTextEdit#logOutput {
     background-color: #FFFFFF;
     border: 1px solid #D0D7E2;


### PR DESCRIPTION
## Summary
- center navigation area on custom page
- split control buttons into two rows and size cancel/ok buttons equally
- support selected color for QTreeWidget
- add clarifying comments on functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c83f5a6c832091a3fd0a32b4f270