### PR TITLE
Add openpyxl dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ source venv/bin/activate
 ```bash
 pip install -r requirements.txt
 ```
+Excel 連携機能を利用するため `openpyxl` も依存関係に含まれています。
 
 ### 3. 初期データの配置
 以下の ZIP ファイルを日本郵便公式サイトからダウンロードし、`resources/` フォルダーに配置してください。

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ tinydb
 requests
 
 pandas
+openpyxl


### PR DESCRIPTION
## Summary
- add `openpyxl` to requirements
- document the dependency in the setup instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858153acd048320a15fe9f6b0901fea