### PR TITLE
Add dynamic loader config GUI

### DIFF
--- a/japanpost_backend/excel_custom_loader.py
+++ b/japanpost_backend/excel_custom_loader.py
@@ -1,0 +1,153 @@
+import json
+from collections import defaultdict
+from typing import Callable, Dict, List, Any
+
+import pandas as pd
+
+
+# ========== I/O ==========
+
+def load_json(path: str) -> Dict[str, Any]:
+    """Load JSON file with UTF-8 encoding."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_json(path: str, obj: dict) -> None:
+    """Save mapping as JSON with UTF-8."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(obj, f, ensure_ascii=False, indent=2)
+
+
+# ========== Utility ==========
+
+def normalize_zip(zipcode: str) -> str:
+    return str(zipcode).zfill(7)
+
+
+def apply_to_zip(df: pd.DataFrame, zip_key: str) -> pd.DataFrame:
+    df[zip_key] = df[zip_key].apply(normalize_zip)
+    return df
+
+
+# ========== Transformation ==========
+
+def to_grouped_list(
+    df: pd.DataFrame,
+    zip_key: str,
+    group_value_key: str,
+    field_name: str,
+) -> Dict[str, Dict[str, List[str]]]:
+    df = apply_to_zip(df, zip_key)
+    grouped = df.groupby(zip_key)[group_value_key].apply(list).to_dict()
+    return {k: {field_name: v} for k, v in grouped.items()}
+
+
+def to_deep_nested_with_values(
+    df: pd.DataFrame,
+    zip_key: str,
+    nest_keys: List[str],
+    value_map: Dict[str, List[str]],
+    field_name: str,
+) -> Dict[str, Dict[str, Any]]:
+    df = apply_to_zip(df, zip_key)
+    result: Dict[str, Dict[str, Any]] = defaultdict(dict)
+
+    for _, row in df.iterrows():
+        zip_val = row[zip_key]
+        current = result[zip_val].setdefault(field_name, {})
+
+        for key in nest_keys:
+            key_val = row[key]
+            next_dict = current.setdefault(key_val, {})
+
+            for vkey in value_map.get(key, []):
+                if vkey in row:
+                    next_dict[vkey] = row[vkey]
+            current = next_dict
+
+    return result
+
+
+def to_dict(
+    df: pd.DataFrame,
+    zip_key: str,
+    value_keys: List[str],
+    field_name: str = None,
+) -> Dict[str, Dict[str, Any]]:
+    df = apply_to_zip(df, zip_key)
+    result: Dict[str, Dict[str, Any]] = defaultdict(dict)
+    for _, row in df.iterrows():
+        zip_val = row[zip_key]
+        values = {key: row.get(key, "") for key in value_keys}
+        if field_name:
+            result[zip_val][field_name] = values
+        else:
+            result[zip_val].update(values)
+    return result
+
+
+# ========== Merge ==========
+
+def merge_dicts(a: dict, b: dict) -> dict:
+    return {**a, **b}
+
+
+# ========== Source Loader ==========
+
+def create_loader(
+    path: str,
+    sheet: str,
+    method: str,
+    args: dict,
+    field_name: str = None,
+) -> Callable[[], Dict[str, dict]]:
+    def load() -> Dict[str, dict]:
+        df = pd.read_excel(path, sheet_name=sheet, dtype=str).fillna("")
+        if method == "grouped_list":
+            return to_grouped_list(df, field_name=field_name, **args)
+        if method == "deep_nested_with_values":
+            return to_deep_nested_with_values(df, field_name=field_name, **args)
+        if method == "dict":
+            return to_dict(df, field_name=field_name, **args)
+        raise ValueError(f"Unsupported method: {method}")
+
+    return load
+
+
+# ========== Custom Builder ==========
+
+def build_customs(loaders: List[Callable[[], Dict[str, dict]]]) -> Dict[str, dict]:
+    customs: Dict[str, dict] = {}
+    for load_fn in loaders:
+        part = load_fn()
+        for zip_key, values in part.items():
+            customs[zip_key] = merge_dicts(customs.get(zip_key, {}), values)
+    return customs
+
+
+# ========== Injection ==========
+
+def inject_customs(
+    address_dict: dict,
+    customs: Dict[str, dict],
+    zip_field: str = "zipcode",
+) -> None:
+    for _, data in address_dict.get("_default", {}).items():
+        zipcode = normalize_zip(data.get(zip_field, ""))
+        if zipcode in customs:
+            data["custom"] = customs[zipcode]
+
+
+# ========== Main Execution ==========
+
+def update_address_json(
+    json_path: str,
+    excel_path: str,
+    loaders: List[Callable[[], Dict[str, dict]]],
+    output_path: str,
+) -> None:
+    address_dict = load_json(json_path)
+    customs = build_customs(loaders)
+    inject_customs(address_dict, customs)
+    save_json(output_path, address_dict)

--- a/tests/test_excel_custom_loader.py
+++ b/tests/test_excel_custom_loader.py
@@ -1,0 +1,80 @@
+import pandas as pd
+from unittest.mock import mock_open
+
+
+def test_update_address_json_dynamic(temp_env, monkeypatch):
+    env = temp_env
+    mod = env["reload"]("japanpost_backend.excel_custom_loader")
+
+    address_dict = {"_default": {"row1": {"zipcode": "1234567"}}}
+    entries_df = pd.DataFrame([
+        {"zipcode": "1234567", "office_code": "O1", "destination_name": "D1", "shiwake_code": "S1"}
+    ])
+    courses_df = pd.DataFrame([
+        {"zipcode": "1234567", "course_code": "C1"}
+    ])
+    variants_df = pd.DataFrame([
+        {
+            "zipcode": "1234567",
+            "pickup_location": "L1",
+            "delivery_type": "T1",
+            "destination_name": "VD1",
+            "shiwake_code": "VS1",
+        }
+    ])
+
+    def fake_read_excel(path, sheet_name=None, dtype=str):
+        if sheet_name == "entries":
+            return entries_df
+        if sheet_name == "course_codes":
+            return courses_df
+        if sheet_name == "pickup_variants":
+            return variants_df
+        return pd.DataFrame()
+
+    monkeypatch.setattr(mod.pd, "read_excel", fake_read_excel)
+    monkeypatch.setattr(mod, "load_json", lambda p: address_dict)
+
+    saved = {}
+    m = mock_open()
+    monkeypatch.setattr("builtins.open", m)
+    monkeypatch.setattr(mod.json, "dump", lambda obj, f, ensure_ascii=False, indent=2: saved.update(obj))
+
+    loaders = [
+        mod.create_loader(
+            path="dummy.xlsx",
+            sheet="entries",
+            method="dict",
+            args={"zip_key": "zipcode", "value_keys": ["office_code", "destination_name", "shiwake_code"]},
+            field_name=None,
+        ),
+        mod.create_loader(
+            path="dummy.xlsx",
+            sheet="course_codes",
+            method="grouped_list",
+            args={"zip_key": "zipcode", "group_value_key": "course_code"},
+            field_name="course_codes",
+        ),
+        mod.create_loader(
+            path="dummy.xlsx",
+            sheet="pickup_variants",
+            method="deep_nested_with_values",
+            args={
+                "zip_key": "zipcode",
+                "nest_keys": ["pickup_location", "delivery_type"],
+                "value_map": {
+                    "pickup_location": ["destination_name"],
+                    "delivery_type": ["shiwake_code"],
+                },
+            },
+            field_name="pickup_variants",
+        ),
+    ]
+
+    mod.update_address_json("addr.json", "dummy.xlsx", loaders, "out.json")
+
+    custom = saved["_default"]["row1"]["custom"]
+    assert custom["office_code"] == "O1"
+    assert custom["course_codes"] == ["C1"]
+    assert custom["pickup_variants"]["L1"]["destination_name"] == "VD1"
+    assert custom["pickup_variants"]["L1"]["T1"]["shiwake_code"] == "VS1"

--- a/views/delivery_setting_page.py
+++ b/views/delivery_setting_page.py
@@ -1,21 +1,111 @@
 from PySide6.QtWidgets import (
     QApplication,
-    QWidget, QVBoxLayout, QLabel, QHBoxLayout,
-    QLineEdit, QPushButton, QTextEdit, QFileDialog, QSizePolicy,
+    QWidget,
+    QVBoxLayout,
+    QLabel,
+    QHBoxLayout,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+    QFileDialog,
+    QSizePolicy,
     QProgressDialog,
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
 )
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, Signal
+import json
+from japanpost_backend import excel_custom_loader as loader_mod
 
-from japanpost_backend.custom_builder import (
-    load_data_strict,
-    normalize_entries,
-    normalize_course_codes,
-    normalize_pickup_variants,
-    build_customs,
-    inject_customs,
-    save_json,
-)
 
+class LoaderConfigBlock(QGroupBox):
+    """Widget representing a single loader configuration block."""
+
+    removed = Signal(object)
+
+    def __init__(self, config: dict | None = None, parent: QWidget | None = None):
+        super().__init__(parent)
+        if config is None:
+            config = {}
+
+        self.setTitle("シート設定")
+        self.form = QFormLayout(self)
+
+        self.sheet_edit = QLineEdit(config.get("sheet", ""))
+        self.form.addRow("シート名", self.sheet_edit)
+
+        self.method_combo = QComboBox()
+        self.method_combo.addItems(["dict", "grouped_list", "deep_nested_with_values"])
+        m = config.get("method", "dict")
+        if m in ["dict", "grouped_list", "deep_nested_with_values"]:
+            self.method_combo.setCurrentText(m)
+        self.form.addRow("処理方法", self.method_combo)
+
+        self.zip_edit = QLineEdit(config.get("args", {}).get("zip_key", "zipcode"))
+        self.form.addRow("zip_key", self.zip_edit)
+
+        self.field_edit = QLineEdit(config.get("field_name") or "")
+        self.form.addRow("field_name", self.field_edit)
+
+        self.args_widget = QWidget()
+        self.args_layout = QFormLayout(self.args_widget)
+        self.form.addRow(self.args_widget)
+
+        self.remove_btn = QPushButton("削除")
+        self.remove_btn.setObjectName("dangerButton")
+        self.form.addRow(self.remove_btn)
+
+        self.method_combo.currentTextChanged.connect(self._refresh_args)
+        self.remove_btn.clicked.connect(lambda: self.removed.emit(self))
+
+        self._refresh_args(config.get("args", {}))
+
+    # --- internal ---
+    def _refresh_args(self, args: dict | None = None) -> None:
+        if args is None:
+            args = {}
+        while self.args_layout.rowCount() > 0:
+            self.args_layout.removeRow(0)
+
+        method = self.method_combo.currentText()
+        if method == "dict":
+            self.value_keys_edit = QLineEdit(",".join(args.get("value_keys", [])))
+            self.args_layout.addRow("value_keys(,区切り)", self.value_keys_edit)
+        elif method == "grouped_list":
+            self.group_value_key_edit = QLineEdit(args.get("group_value_key", ""))
+            self.args_layout.addRow("group_value_key", self.group_value_key_edit)
+        elif method == "deep_nested_with_values":
+            self.nest_keys_edit = QLineEdit(",".join(args.get("nest_keys", [])))
+            self.value_map_edit = QTextEdit(
+                json.dumps(args.get("value_map", {}), ensure_ascii=False, indent=2)
+            )
+            self.args_layout.addRow("nest_keys(,区切り)", self.nest_keys_edit)
+            self.args_layout.addRow("value_map(JSON)", self.value_map_edit)
+
+    # --- public ---
+    def to_config(self) -> dict:
+        method = self.method_combo.currentText()
+        args: dict = {"zip_key": self.zip_edit.text().strip() or "zipcode"}
+        if method == "dict":
+            keys = self.value_keys_edit.text().strip()
+            args["value_keys"] = [k.strip() for k in keys.split(",") if k.strip()]
+        elif method == "grouped_list":
+            args["group_value_key"] = self.group_value_key_edit.text().strip()
+        elif method == "deep_nested_with_values":
+            nest = [k.strip() for k in self.nest_keys_edit.text().split(",") if k.strip()]
+            args["nest_keys"] = nest
+            try:
+                val = json.loads(self.value_map_edit.toPlainText() or "{}")
+            except Exception:
+                val = {}
+            args["value_map"] = val
+        return {
+            "sheet": self.sheet_edit.text().strip(),
+            "method": method,
+            "args": args,
+            "field_name": self.field_edit.text().strip() or None,
+        }
 
 class DeliverySettingPage(QWidget):
     """Page to import custom delivery settings from Excel."""
@@ -23,6 +113,7 @@ class DeliverySettingPage(QWidget):
     def __init__(self, json_path: str):
         super().__init__()
         self.json_path = json_path
+        self.blocks: list[LoaderConfigBlock] = []
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(16, 16, 16, 16)
@@ -62,6 +153,48 @@ class DeliverySettingPage(QWidget):
         file_row.addWidget(self.run_btn)
         layout.addLayout(file_row)
 
+        self.block_area = QVBoxLayout()
+        layout.addLayout(self.block_area)
+
+        self.add_block_btn = QPushButton("＋ シート設定追加")
+        self.add_block_btn.setObjectName("secondaryButton")
+        self.add_block_btn.clicked.connect(lambda: self.add_config_block())
+        layout.addWidget(self.add_block_btn, alignment=Qt.AlignLeft)
+
+        # --- initial template ---
+        default_cfg = [
+            {
+                "sheet": "entries",
+                "method": "dict",
+                "args": {
+                    "zip_key": "zipcode",
+                    "value_keys": ["office_code", "destination_name", "shiwake_code"],
+                },
+                "field_name": None,
+            },
+            {
+                "sheet": "course_codes",
+                "method": "grouped_list",
+                "args": {"zip_key": "zipcode", "group_value_key": "course_code"},
+                "field_name": "course_codes",
+            },
+            {
+                "sheet": "pickup_variants",
+                "method": "deep_nested_with_values",
+                "args": {
+                    "zip_key": "zipcode",
+                    "nest_keys": ["pickup_location", "delivery_type"],
+                    "value_map": {
+                        "pickup_location": ["destination_name"],
+                        "delivery_type": ["shiwake_code"],
+                    },
+                },
+                "field_name": "pickup_variants",
+            },
+        ]
+        for cfg in default_cfg:
+            self.add_config_block(cfg)
+
         layout.addStretch()
 
         self.browse_btn.clicked.connect(self.choose_file)
@@ -91,18 +224,45 @@ class DeliverySettingPage(QWidget):
         progress.setRange(0, 0)
         progress.show()
         QApplication.processEvents()
+        loaders = []
+        for cfg in [b.to_config() for b in self.blocks]:
+            try:
+                loaders.append(
+                    loader_mod.create_loader(
+                        path=excel_path,
+                        sheet=cfg.get("sheet", ""),
+                        method=cfg.get("method", ""),
+                        args=cfg.get("args", {}),
+                        field_name=cfg.get("field_name"),
+                    )
+                )
+            except Exception as e:
+                self.log(f"[ERROR] loader設定エラー: {e}")
+                progress.close()
+                return
+
         try:
-            address_dict, entries_df, courses_df, variants_df = load_data_strict(
-                self.json_path, excel_path
+            loader_mod.update_address_json(
+                json_path=self.json_path,
+                excel_path=excel_path,
+                loaders=loaders,
+                output_path=self.json_path,
             )
-            entries = normalize_entries(entries_df)
-            courses = normalize_course_codes(courses_df)
-            variants = normalize_pickup_variants(variants_df)
-            customs = build_customs(entries, courses, variants)
-            inject_customs(address_dict, customs)
-            save_json(self.json_path, address_dict)
             self.log("[OK] JSONを更新しました")
         except Exception as e:  # pragma: no cover - runtime errors shown to user
             self.log(f"[ERROR] {e}")
         finally:
             progress.close()
+
+    # --- block helpers ---
+    def add_config_block(self, cfg: dict | None = None) -> None:
+        block = LoaderConfigBlock(cfg)
+        block.removed.connect(self.remove_config_block)
+        self.blocks.append(block)
+        self.block_area.addWidget(block)
+
+    def remove_config_block(self, block: LoaderConfigBlock) -> None:
+        if block in self.blocks:
+            self.blocks.remove(block)
+        self.block_area.removeWidget(block)
+        block.deleteLater()


### PR DESCRIPTION
## Summary
- implement `LoaderConfigBlock` widget for per-sheet loader settings
- use multiple loader blocks in `DeliverySettingPage` with add/remove controls
- default template builds entries, course codes, and pickup variants

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859773158188320a15d8f1da6be87e3